### PR TITLE
Http - redirect to another domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ short description for each:
        * `domain`: domain name to serve
        * `redirect_http_to_https`: if this is true, a 301 (Moved Permanently)
          will be sent upon http request to redirect clients to https
+       * `redirect_to_another_domain`: Specify target domain here, something
+         like https://example.com, and all requests arriving to this site's
+         http and https endpoint will be redirected to the target site.
        * `http`: True if we want http traffic to be served
        * `https`: True if we want to serve https traffic
        * `ssl`: A dictionary for ssl config

--- a/ansible/roles/www/templates/site.j2
+++ b/ansible/roles/www/templates/site.j2
@@ -2,10 +2,14 @@
 server {
     listen 80;
     server_name {{ item.domain }};
+{% if item.redirect_http_to_https | default(None) %}
 
-    {% if item.redirect_http_to_https %}
     return 301 https://$host$request_uri;
-    {% endif %}
+{% endif %}
+{% if item.redirect_to_another_domain | default(None) %}
+
+    rewrite ^ {{ item.redirect_to_another_domain }}$request_uri? permanent;
+{% endif %}
 }
 {% endif %}
 
@@ -17,6 +21,10 @@ server {
     server_name {{ item.domain }};
     ssl_certificate {{ item.ssl.cert }};
     ssl_certificate_key {{ item.ssl.privkey }};
+{% if item.redirect_to_another_domain | default('') %}
+
+    rewrite ^ {{ item.redirect_to_another_domain }}$request_uri? permanent;
+{% endif %}
 
     location / {
         # First attempt to serve request as file, then


### PR DESCRIPTION
Add the possibility to redirect to another domain. Also make
redirect_http_to_https optional, defaulting to False. Fixing some
whitespace issues in template.